### PR TITLE
Disable all commands on upgrade

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,8 +15,7 @@ bot = commands.Bot(command_prefix="!", case_insensitive=True, intents=intents)
 bot.help_command = PrettyHelp(show_index=True, sort_commands=True, no_category=True, color=0x00f2ff)
 
 for filename in os.listdir("./cogs"):
-    if filename.endswith(".py") and \
-            filename != "main.py":
+    if filename.endswith(".py") and filename != "upgrade.py":
         bot.load_extension(f"cogs.{filename[:-3]}")
         logger.get_discord_child_logger("cogs").info(f"Loaded: cogs.{filename[:-3]}")
 


### PR DESCRIPTION
fixes #68 

Before doing the upgrade all cogs are unloaded. After the upgrade is done, the bot will need to be restarted

As for why the cogs are not loaded back in see #95 