### PR TITLE
Subjects

### DIFF
--- a/cogs/subjects.py
+++ b/cogs/subjects.py
@@ -1,4 +1,5 @@
 import re
+from operator import attrgetter
 from typing import Union
 
 from discord import Role, TextChannel, Member, User, Guild, Embed
@@ -277,7 +278,7 @@ class Subjects(Cog):
             compatible_study_groups += [document.role for document in all_study_groups if
                                         document.role.name == study_master + str(i)]
         return {str(number): document.subject for number, document in
-                enumerate(await StudySubjectRelations(self.bot).find({})) if
+                enumerate(sorted(await StudySubjectRelations(self.bot).find({}), key=attrgetter("name"))) if
                 document.group in compatible_study_groups}
 
     async def to_change(self, changeable, possible_subjects, subjects):

--- a/cogs/subjects.py
+++ b/cogs/subjects.py
@@ -118,7 +118,10 @@ class Subjects(Cog):
             embed.add_field(name="Opt-in Subjects", value=subjects_text.replace("'", "`").replace(",", "\n"),
                             inline=False)
 
-        embed.add_field(name="Add/Remove subjects", value="```!subject <add|remove> <names|numbers>```", inline=False)
+        embed.add_field(name="Add/Remove subjects", value="```!subject <add|remove> <names|numbers>```\n"
+                                                          "Example:```"
+                                                          "!subject add 0,2,5,7"
+                                                          "```", inline=False)
 
         await ctx.reply(embed=embed)
 

--- a/cogs/subjects.py
+++ b/cogs/subjects.py
@@ -123,7 +123,7 @@ class Subjects(Cog):
                                                           "!subject add 0,2,5,7"
                                                           "```", inline=False)
 
-        await ctx.reply(embed=embed)
+        await ctx.reply(embed=embed, delete_after=300)
 
     @subject.command(pass_context=True,
                      name="add",

--- a/mongo/study_subject_relation.py
+++ b/mongo/study_subject_relation.py
@@ -25,6 +25,10 @@ class StudySubjectRelation(MongoDocument):
             DBKeyWrapperEnum.DEFAULT.value: self.default
         }
 
+    @property
+    def name(self):
+        return self.group.name
+
 
 class StudySubjectRelations(MongoCollection):
     def __init__(self, bot: Bot):


### PR DESCRIPTION
At the moment, the enumeration depends on the position of the roles in the guild.
If these were swapped, the enumeration would be different.
To make it more consistent, an alphabetical enumeration would be better.

But since the enumeration also changes when new roles are added, the show embed should also delete itself after some time to avoid confusion.

I have also added an example.